### PR TITLE
CRAN release prep: docs, license, and cran-comments

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,2 @@
-YEAR: 2023
+YEAR: 2026
 COPYRIGHT HOLDER: hfhub authors

--- a/R/hub_info.R
+++ b/R/hub_info.R
@@ -2,6 +2,14 @@
 #'
 #' @inheritParams hub_download
 #' @param files_metadata Obtain files metadata information when querying repository information.
+#'
+#' @returns A list with information about the repository, including model details,
+#'   file siblings, tags, and other metadata returned by the Hugging Face API.
+#' @examples
+#' try({
+#' info <- hub_repo_info("gpt2")
+#' info$modelId
+#' })
 #' @export
 hub_repo_info <- function(repo_id, ..., repo_type = NULL, revision = NULL, files_metadata = FALSE) {
   if (is.null(repo_type) || repo_type == "model") {

--- a/R/hub_snapshot.R
+++ b/R/hub_snapshot.R
@@ -7,6 +7,15 @@
 #' @param ignore_patterns A character vector contaitning patterns to reject files
 #'   from being downloaded.
 #'
+#' @returns A string with the path to the snapshot directory containing all
+#'   downloaded files.
+#' @examples
+#' try({
+#' withr::with_envvar(c(HUGGINGFACE_HUB_CACHE = tempdir()), {
+#' path <- hub_snapshot("gpt2", allow_patterns = "config.json")
+#' list.files(path)
+#' })
+#' })
 #' @export
 hub_snapshot <- function(repo_id, ..., revision = "main", repo_type = "model",
                          local_files_only = FALSE, force_download = FALSE,

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ remotes::install_github("mlverse/hfhub")
 
 ## Example
 
-`hub_download` the the only exported function in the package and can be used to
+`hub_download` can be used to
 download and cache a file from any Hugging Face Hub repository. It returns a
 path to the file.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,1 +1,9 @@
-Re-submission making requested changes.
+## R CMD check results
+
+0 errors | 0 warnings | 0 notes
+
+## Maintainer change
+
+The maintainer has changed from Daniel Falbel (daniel@posit.co) to
+Tomasz Kalinowski (tomasz@posit.co). Both maintainers work at Posit PBC.
+The previous maintainer has confirmed this change.

--- a/man/hub_repo_info.Rd
+++ b/man/hub_repo_info.Rd
@@ -26,6 +26,10 @@ hub_dataset_info(repo_id, ..., revision = NULL, files_metadata = FALSE)
 
 \item{files_metadata}{Obtain files metadata information when querying repository information.}
 }
+\value{
+A list with information about the repository, including model details,
+file siblings, tags, and other metadata returned by the Hugging Face API.
+}
 \description{
 Queries information about Hub repositories
 }
@@ -34,3 +38,9 @@ Queries information about Hub repositories
 \item \code{hub_dataset_info()}: Query information from a Hub Dataset
 
 }}
+\examples{
+try({
+info <- hub_repo_info("gpt2")
+info$modelId
+})
+}

--- a/man/hub_snapshot.Rd
+++ b/man/hub_snapshot.Rd
@@ -34,6 +34,18 @@ filter allowed files to snapshot.}
 \item{ignore_patterns}{A character vector contaitning patterns to reject files
 from being downloaded.}
 }
+\value{
+A string with the path to the snapshot directory containing all
+downloaded files.
+}
 \description{
 Downloads and stores all files from a Hugging Face Hub repository.
+}
+\examples{
+try({
+withr::with_envvar(c(HUGGINGFACE_HUB_CACHE = tempdir()), {
+path <- hub_snapshot("gpt2", allow_patterns = "config.json")
+list.files(path)
+})
+})
 }

--- a/tests/testthat/_snaps/hub_snapshot.md
+++ b/tests/testthat/_snaps/hub_snapshot.md
@@ -3,7 +3,7 @@
     Code
       p <- hub_snapshot("dfalbel/cran-packages", repo_type = "dataset",
         allow_patterns = "\\.R")
-    Message <cliMessage>
+    Message
       i Snapshotting files 0/4
       v Snapshotting files 4/4 [0ms]
       


### PR DESCRIPTION
## Summary

- Add `@returns` and `@examples` to `hub_repo_info` and `hub_snapshot` (required by CRAN)
- Update LICENSE year to 2026
- Update `cran-comments.md` with maintainer change note
- Fix README typo
- Update test snapshots

## Test plan

- [ ] `devtools::check()` passes cleanly
- [ ] `urlchecker::url_check()` returns no issues